### PR TITLE
Move cstringdist to stringdist.cstringdist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from setuptools import Extension, setup
 # default to the C99 standard (some of the included C code uses C99 syntax)
 c_directory = 'stringdist/cstringdist/'
 cstringdist = Extension(
-    'cstringdist',
+    'stringdist.cstringdist',
     sources=[
         c_directory + 'cstringdist.c',
         c_directory + 'levenshtein.c',

--- a/stringdist/__init__.py
+++ b/stringdist/__init__.py
@@ -5,7 +5,7 @@
 # the Python implementation as needed. This allows library users to import from
 # stringdist without worrying about which implementation was selected
 try:
-    from cstringdist import (levenshtein, levenshtein_norm, rdlevenshtein,
+    from .cstringdist import (levenshtein, levenshtein_norm, rdlevenshtein,
                              rdlevenshtein_norm)
 except ImportError:
     from .pystringdist import (levenshtein, levenshtein_norm, rdlevenshtein,

--- a/stringdist/cstringdist/cstringdist.c
+++ b/stringdist/cstringdist/cstringdist.c
@@ -48,7 +48,7 @@ static PyMethodDef methods[] = {
 // Create PyModuleDef struct, which outlines the desired C extension module
 static struct PyModuleDef cstringdist = {
     PyModuleDef_HEAD_INIT,
-    "cstringdist",
+    "stringdist.cstringdist",
     "Calculates several different string distance metrics",
     -1,
     methods,


### PR DESCRIPTION
Similar to stringdist.pystringdist, make cstringdist a submodule instead of a top-level module.

Fixes #1